### PR TITLE
fix: Fix "Reason: no LC_RPATH's found" error, and remove useless include header.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,40 +1,29 @@
-name: Build
-
+name: SonarQube
 on:
   push:
     branches:
       - main
   pull_request:
     types: [opened, synchronize, reopened]
-
 jobs:
   build:
-    name: Build
+    name: Build and analyze
     runs-on: ubuntu-latest
+    env:
+      BUILD_WRAPPER_OUT_DIR: build_wrapper_output_directory # Directory where build-wrapper output will be placed
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-      - name: Download and install the build wrapper, build the project
+      - name: Install Build Wrapper
+        uses: SonarSource/sonarqube-scan-action/install-build-wrapper@v5
+      - name: Run Build Wrapper
         run: |
-          mkdir $HOME/.sonar
-          curl -sSLo $HOME/.sonar/build-wrapper-linux-x86.zip ${{ secrets.SONAR_HOST_URL }}/static/cpp/build-wrapper-linux-x86.zip
-          unzip -o $HOME/.sonar/build-wrapper-linux-x86.zip -d $HOME/.sonar/
-          $HOME/.sonar/build-wrapper-linux-x86/build-wrapper-linux-x86-64 --out-dir bw-output ./build.sh && ./run-debug.sh
-        env:
-          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
-
-      - name: Download and install the SonarScanner
-        env:
-          SONAR_SCANNER_VERSION: 4.6.2.2472
-        run: |
-          curl -sSLo $HOME/.sonar/sonar-scanner.zip https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${{ env.SONAR_SCANNER_VERSION }}-linux.zip
-          unzip -o $HOME/.sonar/sonar-scanner.zip -d $HOME/.sonar/
-          echo "$HOME/.sonar/sonar-scanner-${{ env.SONAR_SCANNER_VERSION }}-linux/bin" >> $GITHUB_PATH
-
-      - name: SonarQube analysis
-        run: |
-          sonar-scanner --define sonar.cfamily.build-wrapper-output=bw-output
+          build-wrapper-linux-x86-64 --out-dir ${{ env.BUILD_WRAPPER_OUT_DIR }} ./build.sh && ./run-debug.sh
+      - name: SonarQube Scan
+        uses: SonarSource/sonarqube-scan-action@v5
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+        with:
+          args: >
+            --define sonar.cfamily.compile-commands="${{ env.BUILD_WRAPPER_OUT_DIR }}/compile_commands.json"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # C Tools
 
+[![Build](https://github.com/shawngao-org/c_tools/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/shawngao-org/c_tools/actions/workflows/build.yml)
+
 + This project is a C language tool library.
 + This project will encapsulate some commonly used tools and functions.
 + This project has not been developed yet and many functions need to be added.

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,1 +1,14 @@
-sonar.projectKey=shawngao-org_c_tools_AZYi4S3REsRBMwiLwfO-
+sonar.projectKey=shawngao-org_c_tools
+sonar.organization=shawngao-org
+
+
+# This is the name and version displayed in the SonarCloud UI.
+#sonar.projectName=c_tools
+#sonar.projectVersion=1.0
+
+
+# Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
+#sonar.sources=.
+
+# Encoding of the source code. Default is default system encoding
+#sonar.sourceEncoding=UTF-8

--- a/src/string/string_tools.c
+++ b/src/string/string_tools.c
@@ -7,7 +7,6 @@
 #include <ctype.h>
 #include <math.h>
 #include <stdio.h>
-#include <stdlib.h>
 
 unsigned long safe_strlen(const char *str) {
     if (str == NULL || str[0] == '\0')

--- a/tools-debug/build-debug.sh
+++ b/tools-debug/build-debug.sh
@@ -20,6 +20,7 @@ else
   exit 1
 fi
 
+export DYLD_LIBRARY_PATH=/usr/local/lib
 system=`uname`
 if [ "$system" != "Darwin" ]; then
   strace -f ./tools_debug


### PR DESCRIPTION
## Summary by Sourcery

Update CI/CD workflow to use latest SonarQube GitHub Actions and improve project configuration

Enhancements:
- Simplify SonarQube configuration in GitHub Actions workflow
- Update sonar-project.properties with more explicit configuration

Build:
- Add DYLD_LIBRARY_PATH export in build-debug.sh to resolve potential library path issues

CI:
- Migrate GitHub Actions workflow to use official SonarSource actions for build and scanning
- Update workflow to use more recent checkout and SonarQube scanning actions

Chores:
- Remove unnecessary include in string_tools.c
- Add build status badge to README.md