### PR TITLE
refactor(time): supports Cygwin and MinGW environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,4 @@
 build
 cmake-build-debug
+cmake-build-debug-*
 .idea
-
-tools-debug/cmake-build-debug
-tools-debug/.idea
-tools-debug/.cmake
-tools-debug/CMakeFiles
-tools-debug/Testing
-tools-debug/tools_debug

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@
 
 ## Build & Run
 
+#### Requirements
+
++ CMake 3.27 or higher
+
 #### Linux & macOS
 
 ```shell
@@ -39,7 +43,7 @@
 
 #### Install library to system
 
-> This method is not support for Windows. Please see [Include library in your project](#include-library-in-your-project).
+> This method is not supported for Windows. Please see [Include library in your project](#include-library-in-your-project).
 
 ```shell
 cd build

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 + This project will encapsulate some commonly used tools and functions.
 + This project has not been developed yet and many functions need to be added.
 
-## Build & Run Debug program
+## Build & Run
 
 #### Linux & macOS
 
@@ -23,19 +23,143 @@
 
 #### Windows
 
+> You need to install `Cygwin`(Recommended) or `MingW` to compile and run Windows programs.
+
+> If you want to use `MingW` to compile and run Windows programs, you need to change `build.bat` file.
+
 ```shell
 # build and test
 .\build.bat
 .\build\tests.exe
 ```
 
+## Usage
+
+### Install library to system, or include library in your project
+
+#### Install library to system
+
+> This method is not support for Windows. Please see [Include library in your project](#include-library-in-your-project).
+
+```shell
+cd build
+make install
+# If Linux OS
+sudo ldconfig
+```
+
+#### Include library in your project
+
+Create `lib` directory in your project and create `include` directory in `lib` directory.
+
+```text
+project_root/
+├── CMakeLists.txt
+└── lib/
+    └── include/
+```
+
+Copy `include/tools.h` to `lib/include/` directory.
+
+Copy libraries to `lib` directory:
+
++ MacOS: `build/libtools.dylib` and `build/libtools.1.0.0.dylib`
+
++ Linux: `build/libtools.so` and `build/libtools.so.1.0`
+
++ Windows + Cygwin: `build/libtools.dll.a` and `build/cygtools.dll`
+
++ Windows + MingW: `build/libtools.dll.a` and `build/libtools.dll`
+
+```text
+project_root/
+├── CMakeLists.txt
+└── lib/
+    ├── include/
+    │   └── tools.h
+    ├── libtools.dll # Windows with MingW
+    ├── cygtools.dll # Windows with Cygwin
+    ├── libtools.dll.a # Windows
+    ├── libtools.so # Linux
+    ├── libtools.so.1.0 # Linux
+    ├── libtools.dylib # macOS
+    └── libtools.1.0.0.dylib # macOS
+```
+
+CMakeLists.txt example:
+
+```cmake
+# tools_example replace with your project name
+cmake_minimum_required(VERSION 3.27)
+project(tools_example C)
+
+set(CMAKE_C_STANDARD 11)
+
+add_executable(tools_example main.c)
+
+target_include_directories(tools_example PRIVATE lib/include)
+target_link_directories(tools_example PRIVATE lib)
+target_link_libraries(tools_example tools)
+```
+
+main.c example:
+
+```c
+#include "tools.h"
+
+int main() {
+    hello();
+    return 0;
+}
+```
+
+If you run `./tools_example` you will see:
+
+```text
+Hello, World!
+```
+
+This means you can use this library for development.
+
+## Bugs
+
++ If you find a bug, please open an issue.
++ If you want to fix a bug or add a feature, please open a pull request.
+
+## Contributing
+
++ Fork this repository.
++ Make your changes.
++ Commit your changes.
++ Push your changes.
++ Create a pull request.
++ Wait for the maintainer to review your pull request.
+
 ## License
 This project is licensed under the **MIT** License - see the LICENSE.md file for details.
 
 ## Acknowledgments
+
+### CLion
 
 > CLion is an IDE that maximizes developer productivity in every aspect.
 
 Special thanks to JetBrains for providing a free CLion license for open source and educational learning.
 
 <img src="./image/jetbrains-variant-3.png" alt="Logo" width="200"/>
+
+### SonarQube Cloud
+
+> SaaS solution for high quality code. Simple, scalable, fast.
+
+Special thanks to SonarSource for providing a free SonarQube Cloud Free Plan for open source.
+
+<img src="https://assets-eu-01.kc-usercontent.com/5dddefee-e8bb-013a-3b4e-7907971cf825/049542ea-4991-4e9e-81ea-8744c3ae685b/SQ-Cloud_Horizontal%402x.png" alt="Logo" width="200"/>
+
+### Sourcery AI
+
+> Sourcery is an AI-powered code review tool that helps developers find bugs, vulnerabilities, and security issues in their code.
+
+Special thanks to Sourcery for providing a free plan Sourcery AI for open source.
+
+<img src="https://sourcery.ai/_astro/sourcery-dark.CjCiMq8g_Z1W5FsC.svg" alt="Logo" width="200">

--- a/build.bat
+++ b/build.bat
@@ -10,9 +10,12 @@ echo Creating directory and enter %DIRECTORY%
 mkdir "%DIRECTORY%"
 cd "%DIRECTORY%"
 echo CMaking...
-cmake -G "MinGW Makefiles" ..
+@REM If you are using MinGW, use the following command instead:
+@REM cmake -G "MinGW Makefiles" ..
+@REM If you are using Cygwin, use the following command instead:
+cmake -G "Unix Makefiles" ..
 echo Making...
-mingw32-make.exe -j 2
+make.exe -j 2
 if %errorlevel% equ 0 (
   echo Build Successful!
 ) else (
@@ -20,4 +23,4 @@ if %errorlevel% equ 0 (
   exit /b 1
 )
 echo Testing...
-mingw32-make.exe test
+make.exe test

--- a/include/time/time_tools.h
+++ b/include/time/time_tools.h
@@ -7,7 +7,7 @@
 #include <time.h>
 
 struct timestamp {
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__MINGW32__) || defined(__MINGW64__)
     long long val;
 #else
     long val;

--- a/include/tools.h
+++ b/include/tools.h
@@ -4,7 +4,7 @@
 #include <time.h>
 
 struct timestamp {
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__MINGW32__) || defined(__MINGW64__)
     long long val;
 #else
     long val;

--- a/src/time/time_tools.c
+++ b/src/time/time_tools.c
@@ -12,6 +12,10 @@
 #include <stdio.h>
 #include <stdarg.h>
 
+#if defined(_WIN32) || defined(__MINGW32__) || defined(__MINGW64__) || defined(__CYGWIN__)
+#include <errno.h>
+#endif
+
 #if defined(_WIN32) || defined(__MINGW32__) || defined(__MINGW64__)
 #define TIMESTAMP_TOKEN_FMT "%lld"
 #else
@@ -46,7 +50,7 @@ char *get_time_string(const struct tm *time) {
     return buffer;
 }
 
-#if defined(_WIN32) || defined(__MINGW32__) || defined(__MINGW64__)
+#if defined(_WIN32) || defined(__MINGW32__) || defined(__MINGW64__) || defined(__CYGWIN__)
 void win_strptime(const char *s, const char *format, struct tm *tm) {
     if (tm == NULL) {
         return;
@@ -108,9 +112,9 @@ void win_strptime(const char *s, const char *format, struct tm *tm) {
 
 struct tm *get_time_by_string(char *time_string) {
     struct tm *time = (struct tm *) malloc(sizeof(struct tm));
-#if defined(_WIN32) || defined(__MINGW32__) || defined(__MINGW64__)
+#if defined(_WIN32) || defined(__MINGW32__) || defined(__MINGW64__) || defined(__CYGWIN__)
     win_strptime(time_string, "%Y-%m-%d %H:%M:%S", time);
-#elif defined(__linux__) || defined(__APPLE__) || defined(__CYGWIN__)
+#elif defined(__linux__) || defined(__APPLE__)
     strptime(time_string, "%Y-%m-%d %H:%M:%S", time);
 #else
     return NULL;

--- a/src/time/time_tools.c
+++ b/src/time/time_tools.c
@@ -12,7 +12,7 @@
 #include <stdio.h>
 #include <stdarg.h>
 
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__MINGW32__) || defined(__MINGW64__)
 #define TIMESTAMP_TOKEN_FMT "%lld"
 #else
 #define TIMESTAMP_TOKEN_FMT "%ld"
@@ -22,9 +22,9 @@ struct tm* safe_localtime(const time_t *time_ptr, struct tm *buf) {
     if (buf == NULL) {
         return NULL;
     }
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__MINGW32__) || defined(__MINGW64__)
     if (localtime_s(buf, time_ptr) != 0) return NULL;
-#elif defined(__linux__) || defined(__APPLE__)
+#elif defined(__linux__) || defined(__APPLE__) || defined(__CYGWIN__)
     if (localtime_r(time_ptr, buf) == NULL) return NULL;
 #else
     return NULL;
@@ -46,7 +46,7 @@ char *get_time_string(const struct tm *time) {
     return buffer;
 }
 
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__MINGW32__) || defined(__MINGW64__)
 void win_strptime(const char *s, const char *format, struct tm *tm) {
     if (tm == NULL) {
         return;
@@ -108,9 +108,9 @@ void win_strptime(const char *s, const char *format, struct tm *tm) {
 
 struct tm *get_time_by_string(char *time_string) {
     struct tm *time = (struct tm *) malloc(sizeof(struct tm));
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__MINGW32__) || defined(__MINGW64__)
     win_strptime(time_string, "%Y-%m-%d %H:%M:%S", time);
-#elif defined(__linux__) || defined(__APPLE__)
+#elif defined(__linux__) || defined(__APPLE__) || defined(__CYGWIN__)
     strptime(time_string, "%Y-%m-%d %H:%M:%S", time);
 #else
     return NULL;

--- a/tests/time_test/time_test.c
+++ b/tests/time_test/time_test.c
@@ -158,7 +158,7 @@ void test_get_days_in_month() {
 
 int time_test() {
     hello();
-#if defined(__linux__) || defined(__APPLE__)
+#if defined(__linux__) || defined(__APPLE__) || defined(__CYGWIN__)
     setenv("TZ", "Etc/GMT-8", 1);
     tzset();
 #endif


### PR DESCRIPTION
## Summary by Sourcery

Add support for Cygwin and MinGW environments in the time tools library

New Features:
- Add cross-platform compatibility for time-related functions in Windows environments

Enhancements:
- Extend platform-specific time handling to support Cygwin and MinGW environments
- Update build scripts to work with both Cygwin and MinGW build systems

Documentation:
- Expand README with detailed instructions for library installation and usage across different platforms
- Add documentation for Windows-specific library integration

Chores:
- Update preprocessor macros to handle Cygwin and MinGW platform detection
- Modify build and test scripts to support different Windows development environments